### PR TITLE
when computing start time, don't pad the numbers with zeros or java gets confused

### DIFF
--- a/1-measured/record-start-time.sh
+++ b/1-measured/record-start-time.sh
@@ -4,7 +4,7 @@ set -e
 
 tmpfile=$(mktemp /tmp/tilt-example-java.XXXXXX)
 cat src/main/java/dev/tilt/example/IndexController.java | \
-    sed -e "s/startTimeSecs = .*;/startTimeSecs = $(date +%s);/" | \
-    sed -e "s/startTimeNanos = .*;/startTimeNanos = $(date +%N);/" > \
+    sed -e "s/startTimeSecs = .*;/startTimeSecs = $(date +%-s);/" | \
+    sed -e "s/startTimeNanos = .*;/startTimeNanos = $(date +%-N);/" > \
     $tmpfile
 mv $tmpfile src/main/java/dev/tilt/example/IndexController.java

--- a/2-optimized/record-start-time.sh
+++ b/2-optimized/record-start-time.sh
@@ -4,7 +4,7 @@ set -e
 
 tmpfile=$(mktemp /tmp/tilt-example-java.XXXXXX)
 cat src/main/java/dev/tilt/example/IndexController.java | \
-    sed -e "s/startTimeSecs = .*;/startTimeSecs = $(date +%s);/" | \
-    sed -e "s/startTimeNanos = .*;/startTimeNanos = $(date +%N);/" > \
+    sed -e "s/startTimeSecs = .*;/startTimeSecs = $(date +%-s);/" | \
+    sed -e "s/startTimeNanos = .*;/startTimeNanos = $(date +%-N);/" > \
     $tmpfile
 mv $tmpfile src/main/java/dev/tilt/example/IndexController.java

--- a/2-optimized/src/main/java/dev/tilt/example/IndexController.java
+++ b/2-optimized/src/main/java/dev/tilt/example/IndexController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class IndexController {
-  private final long startTimeSecs = 1584484403;
-  private final long startTimeNanos = 644907706;
+  private final long startTimeSecs = 1584487295;
+  private final long startTimeNanos = 295627452;
   private final String updateDuration;
 
   public IndexController() {

--- a/3-recommended/record-start-time.sh
+++ b/3-recommended/record-start-time.sh
@@ -4,7 +4,7 @@ set -e
 
 tmpfile=$(mktemp /tmp/tilt-example-java.XXXXXX)
 cat src/main/java/dev/tilt/example/IndexController.java | \
-    sed -e "s/startTimeSecs = .*;/startTimeSecs = $(date +%s);/" | \
-    sed -e "s/startTimeNanos = .*;/startTimeNanos = $(date +%N);/" > \
+    sed -e "s/startTimeSecs = .*;/startTimeSecs = $(date +%-s);/" | \
+    sed -e "s/startTimeNanos = .*;/startTimeNanos = $(date +%-N);/" > \
     $tmpfile
 mv $tmpfile src/main/java/dev/tilt/example/IndexController.java

--- a/3-recommended/src/main/java/dev/tilt/example/IndexController.java
+++ b/3-recommended/src/main/java/dev/tilt/example/IndexController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class IndexController {
-  private final long startTimeSecs = 1584485551;
-  private final long startTimeNanos = 152370994;
+  private final long startTimeSecs = 1584487413;
+  private final long startTimeNanos = 950683561;
   private final String updateDuration;
 
   public IndexController() {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/pad:

7241788cd0e8b8101e4753e4a328d7eda35b481f (2020-03-17 19:24:56 -0400)
when computing start time, don't pad the numbers with zeros or java gets confused

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics