### PR TITLE
update circleci to use the :latest image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: tiltdev/circleci-tilt:v0.13.0
+      - image: tiltdev/tilt:latest
 
     steps:
       - setup_remote_docker


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/circleci:

95eb0ca086c45668d743c62ca79b9b96b6fc2903 (2020-04-14 14:10:30 -0400)
update circleci to use the :latest image

f874958049e221d5639a817b9c8abd2486356a2b (2020-04-03 18:50:50 -0400)
circleci: add integration tests

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics