### PR TITLE
java-example: don't keep files around forever

### DIFF
--- a/4-recommended/Tiltfile
+++ b/4-recommended/Tiltfile
@@ -18,8 +18,9 @@ if os.name == "nt":
 local_resource(
   'example-java-compile',
   gradlew + ' bootJar && ' +
+  'rm -rf build/jar-staging && ' +
   'unzip -o build/libs/example-0.0.1-SNAPSHOT.jar -d build/jar-staging && ' +
-  'rsync --inplace --checksum -r build/jar-staging/ build/jar',
+  'rsync --delete --inplace --checksum -r build/jar-staging/ build/jar',
   deps=['src', 'build.gradle'],
   resource_deps = ['deploy'])
 


### PR DESCRIPTION
### Problem

If you create a .java file, build, then delete that .java file, the .class file continues to get included in the docker images and live updates, which can lead to problems (see item 2 in [#3312](https://github.com/tilt-dev/tilt/issues/3312)). This is because we are copying the new class files over old class files, and there's no mechanism to clean up any class files that don't exist in the new build.

### Solution

Fix the two spots where we were failing to delete old .class files.